### PR TITLE
Install valgrind in CI setup

### DIFF
--- a/.agent/deps.sh
+++ b/.agent/deps.sh
@@ -8,6 +8,7 @@ apt install -y build-essential autoconf automake libtool pkg-config \
     libgtest-dev python-dev-is-python3 swig default-jdk flex bison cython3 gperf \
     libsparsehash-dev pandoc \
     libbsd-dev \
+    valgrind \
     autoconf-archive &
 APT_PID=$!
 


### PR DESCRIPTION
## Summary
- install `valgrind` in the dependency setup script

## Testing
- `./.agent/setup.sh` *(fails: Unable to fetch packages)*