### PR TITLE
Add prek-based lint hooks and CI matrix

### DIFF
--- a/.agent/Makefile
+++ b/.agent/Makefile
@@ -3,11 +3,14 @@ ifeq ($(shell [ $(THREADS) -gt 8 ] && echo yes),yes)
 THREADS := 8
 endif
 
-.PHONY: all clones libmacaroons
+.PHONY: all clones lint libmacaroons
 
 all: libmacaroons
 
 clones:
+
+lint:
+	./check.sh
 
 libmacaroons:
 	cd .. && autoreconf -i

--- a/.agent/check.sh
+++ b/.agent/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$REPO_ROOT"
+scripts/install-prek.sh
+export PATH="$HOME/.local/bin:$PATH"
+exec prek run --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,35 @@ on:
   pull_request:
 
 jobs:
+  prek-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.hooks.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: hooks
+      name: List prek hooks
+      run: echo "matrix=$(python3 scripts/list-prek-hooks.py)" >> "$GITHUB_OUTPUT"
+
+  prek:
+    name: prek / ${{ matrix.id }}
+    needs: prek-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prek-matrix.outputs.matrix) }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install prek
+      run: scripts/install-prek.sh
+    - name: Add local bin to PATH
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Run prek hook
+      run: prek run --all-files "${{ matrix.id }}"
+
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run setup and tests
       run: sudo ./.agent/setup.sh
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: local
+    hooks:
+      - id: workflow-audit
+        name: github actions audit
+        entry: scripts/check-actions.sh
+        language: system
+        pass_filenames: false
+        files: ^\.github/workflows/.*\.ya?ml$
+
+      - id: shell-syntax
+        name: shell syntax
+        entry: scripts/check-shell-syntax.sh
+        language: system
+        pass_filenames: false
+        files: ^(\.agent|scripts|test)/.*\.sh$

--- a/scripts/check-actions.sh
+++ b/scripts/check-actions.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+cd "$REPO_ROOT"
+
+if [ ! -d .github/workflows ]; then
+  echo "No .github/workflows directory found; skipping workflow audit."
+  exit 0
+fi
+
+ACTIONLINT_BIN="$(scripts/install-actionlint.sh)"
+"$ACTIONLINT_BIN"

--- a/scripts/check-shell-syntax.sh
+++ b/scripts/check-shell-syntax.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+cd "$REPO_ROOT"
+
+mapfile -t shell_files < <(git ls-files '*.sh' '.agent/*.sh' 'scripts/*.sh' 'test/*.sh' 'test/**/*.sh')
+
+if [ "${#shell_files[@]}" -eq 0 ]; then
+  echo "No shell files found."
+  exit 0
+fi
+
+bash -n "${shell_files[@]}"

--- a/scripts/install-actionlint.sh
+++ b/scripts/install-actionlint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+ACTIONLINT_VERSION="${ACTIONLINT_VERSION:-1.7.11}"
+ACTIONLINT_SHA256_LINUX_AMD64="${ACTIONLINT_SHA256_LINUX_AMD64:-900919a84f2229bac68ca9cd4103ea297abc35e9689ebb842c6e34a3d1b01b0a}"
+ACTIONLINT_BIN="${ACTIONLINT_BIN:-}"
+CACHE_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/hyperdex-family/tools"
+ACTIONLINT_ROOT="${CACHE_ROOT}/actionlint/${ACTIONLINT_VERSION}"
+
+cd "$REPO_ROOT"
+
+if [ -n "$ACTIONLINT_BIN" ]; then
+  printf '%s\n' "$ACTIONLINT_BIN"
+  exit 0
+fi
+
+if command -v actionlint >/dev/null 2>&1; then
+  command -v actionlint
+  exit 0
+fi
+
+mkdir -p "$ACTIONLINT_ROOT"
+
+if [ ! -x "${ACTIONLINT_ROOT}/actionlint" ]; then
+  archive="$(mktemp -t actionlint.XXXXXX.tar.gz)"
+  trap 'rm -f "$archive"' EXIT
+  curl -L --fail --silent --show-error \
+    "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    -o "$archive"
+  printf '%s  %s\n' "$ACTIONLINT_SHA256_LINUX_AMD64" "$archive" | sha256sum --check --status
+  tar -xzf "$archive" -C "$ACTIONLINT_ROOT" actionlint
+fi
+
+printf '%s\n' "${ACTIONLINT_ROOT}/actionlint"

--- a/scripts/install-prek.sh
+++ b/scripts/install-prek.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PREK_VERSION="${PREK_VERSION:-0.3.8}"
+PREK_SHA256_X86_64_UNKNOWN_LINUX_GNU="${PREK_SHA256_X86_64_UNKNOWN_LINUX_GNU:-80ec6adb9f1883344de52cb943d371ecfd25340c4a6b5b81e2600d27e246cfa1}"
+LOCAL_BIN="${LOCAL_BIN:-$HOME/.local/bin}"
+
+cd "$REPO_ROOT"
+
+if command -v prek >/dev/null 2>&1 && prek --version 2>/dev/null | grep -q "$PREK_VERSION"; then
+  exit 0
+fi
+
+mkdir -p "$LOCAL_BIN"
+archive="$(mktemp -t prek.XXXXXX.tar.gz)"
+trap 'rm -f "$archive"' EXIT
+curl -L --fail --silent --show-error \
+  "https://github.com/j178/prek/releases/download/v${PREK_VERSION}/prek-x86_64-unknown-linux-gnu.tar.gz" \
+  -o "$archive"
+printf '%s  %s\n' "$PREK_SHA256_X86_64_UNKNOWN_LINUX_GNU" "$archive" | sha256sum --check --status
+tar -xzf "$archive" -C "$LOCAL_BIN" --strip-components=1 prek-x86_64-unknown-linux-gnu/prek
+chmod +x "${LOCAL_BIN}/prek"

--- a/scripts/list-prek-hooks.py
+++ b/scripts/list-prek-hooks.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+
+
+CONFIG_PATH = Path(".pre-commit-config.yaml")
+HOOK_ID_RE = re.compile(r"^\s*-\s+id:\s+(.+?)\s*$")
+STAGES_RE = re.compile(r"^\s*stages:\s*\[(.*?)\]\s*$")
+
+
+def parse_hooks() -> list[dict[str, object]]:
+    hooks: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+
+    for raw_line in CONFIG_PATH.read_text().splitlines():
+        hook_match = HOOK_ID_RE.match(raw_line)
+        if hook_match:
+            if current is not None:
+                hooks.append(current)
+            current = {"id": hook_match.group(1), "stages": None}
+            continue
+
+        if current is None:
+            continue
+
+        stages_match = STAGES_RE.match(raw_line)
+        if stages_match:
+            stages = [
+                stage.strip().strip("'\"")
+                for stage in stages_match.group(1).split(",")
+                if stage.strip()
+            ]
+            current["stages"] = stages
+
+    if current is not None:
+        hooks.append(current)
+
+    return hooks
+
+
+def main() -> None:
+    hooks = []
+    for hook in parse_hooks():
+      stages = hook["stages"]
+      if stages is not None and "pre-commit" not in stages:
+          continue
+      hooks.append({"id": hook["id"]})
+
+    print(json.dumps({"include": hooks}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a lightweight prek baseline for workflow lint and shell syntax
- expose a local .agent/check.sh path that runs the repo hooks
- run the hooks as separate GitHub Actions jobs for faster feedback while preserving the existing build job